### PR TITLE
Disney channel now uses HLS so changed plist

### DIFF
--- a/Contents/Info.plist
+++ b/Contents/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.plexapp.plugins.disney</string>
 	<key>PlexClientPlatforms</key>
-	<string>*</string>
+	<string>Android,iOS,Roku,Safari</string>
 	<key>PlexFrameworkVersion</key>
 	<string>2</string>
 	<key>PlexPluginRegions</key>


### PR DESCRIPTION
The channel has been using HLS for awhile now but the plist did not limit it to clients that work with HLS. This fixes that.